### PR TITLE
chore: update dead link

### DIFF
--- a/spongefish/src/traits.rs
+++ b/spongefish/src/traits.rs
@@ -29,7 +29,7 @@ pub trait CommonUnitToBytes {
 /// In particular, the implementation of this trait is expected to provide different guarantees between units `u8`
 /// and $\mathbb{F}_p$ elements:
 /// - `u8` implementations are assumed to be streaming-friendly, that is: `implementor.fill_challenge_bytes(&mut out[..1]); implementor.fill_challenge_bytes(&mut out[1..]);` is expected to be equivalent to `implementor.fill_challenge_bytes(&mut out);`.
-/// - $\mathbb{F}_p$ implementations are expected to provide no such guarantee. In addition, we expect the implementation to return bytes that are uniformly distributed. In particular, note that the most significant bytes of a $\mod p$ element are not uniformly distributed. The number of bytes good to be used can be discovered playing with [our scripts](https://github.com/arkworks-rs/spongefish/blob/main/scripts/useful_bits_modp.py).
+/// - $\mathbb{F}_p$ implementations are expected to provide no such guarantee. In addition, we expect the implementation to return bytes that are uniformly distributed. In particular, note that the most significant bytes of a $\mod p$ element are not uniformly distributed. The number of bytes good to be used can be discovered playing with [our scripts](https://github.com/arkworks-rs/spongefish/blob/main/spongefish/scripts/useful_bits_modp.py).
 pub trait UnitToBytes {
     fn fill_challenge_bytes(&mut self, output: &mut [u8]) -> Result<(), DomainSeparatorMismatch>;
 


### PR DESCRIPTION
Hi! I fixed a broken link to the `useful_bits_modp.py` script in the Spongefish repository. The previous link pointed to an incorrect path that no longer exists.