### PR TITLE
UnitToBytes(De)Serialize should be BytesToUnit(De)Serialize

### DIFF
--- a/spongefish-poseidon/examples/schnorr_algebraic_hash.rs
+++ b/spongefish-poseidon/examples/schnorr_algebraic_hash.rs
@@ -59,7 +59,7 @@ where
     G::BaseField: PrimeField,
     H: DuplexSpongeInterface<U>,
     G: CurveGroup,
-    ProverState<H, U>: GroupToUnit<G> + FieldToUnit<G::BaseField> + UnitToBytes,
+    ProverState<H, U>: GroupToUnitSerialize<G> + FieldToUnitSerialize<G::BaseField> + UnitToBytes,
 {
     // `ProverState` types implement a cryptographically-secure random number generator that is tied to the protocol transcript
     // and that can be accessed via the `rng()` function.
@@ -103,7 +103,8 @@ where
     G::BaseField: PrimeField,
     G: CurveGroup,
     H: DuplexSpongeInterface<U>,
-    VerifierState<'a, H, U>: DeserializeGroup<G> + DeserializeField<G::BaseField> + UnitToBytes,
+    VerifierState<'a, H, U>:
+        GroupToUnitDeserialize<G> + FieldToUnitDeserialize<G::BaseField> + UnitToBytes,
 {
     // Read the protocol from the transcript:
     let [K] = verifier_state.next_points()?;

--- a/spongefish-pow/src/blake3.rs
+++ b/spongefish-pow/src/blake3.rs
@@ -145,8 +145,8 @@ impl Blake3PoW {
 #[test]
 fn test_pow_blake3() {
     use crate::{
-        ByteDomainSeparator, PoWChallenge, PoWDomainSeparator, UnitToBytesDeserialize,
-        UnitToBytesSerialize,
+        ByteDomainSeparator, BytesToUnitDeserialize, BytesToUnitSerialize, PoWChallenge,
+        PoWDomainSeparator,
     };
     use spongefish::{DefaultHash, DomainSeparator};
 

--- a/spongefish-pow/src/keccak.rs
+++ b/spongefish-pow/src/keccak.rs
@@ -31,8 +31,8 @@ impl PowStrategy for KeccakPoW {
 #[test]
 fn test_pow_keccak() {
     use crate::{
-        ByteDomainSeparator, PoWChallenge, PoWDomainSeparator, UnitToBytesDeserialize,
-        UnitToBytesSerialize,
+        ByteDomainSeparator, BytesToUnitDeserialize, BytesToUnitSerialize, PoWChallenge,
+        PoWDomainSeparator,
     };
     use spongefish::{DefaultHash, DomainSeparator};
 

--- a/spongefish-pow/src/lib.rs
+++ b/spongefish-pow/src/lib.rs
@@ -2,8 +2,8 @@ pub mod blake3;
 pub mod keccak;
 
 use spongefish::{
-    ByteDomainSeparator, DuplexSpongeInterface, ProofError, ProofResult, ProverState, Unit,
-    UnitToBytes, UnitToBytesDeserialize, UnitToBytesSerialize, VerifierState,
+    ByteDomainSeparator, BytesToUnitDeserialize, BytesToUnitSerialize, DuplexSpongeInterface,
+    ProofError, ProofResult, ProverState, Unit, UnitToBytes, VerifierState,
 };
 
 /// [`spongefish::DomainSeparator`] for proof-of-work challenges.
@@ -41,7 +41,7 @@ where
     U: Unit,
     H: DuplexSpongeInterface<U>,
     R: rand::CryptoRng + rand::RngCore,
-    ProverState<H, U, R>: UnitToBytesSerialize + UnitToBytes,
+    ProverState<H, U, R>: BytesToUnitSerialize + UnitToBytes,
 {
     fn challenge_pow<S: PowStrategy>(&mut self, bits: f64) -> ProofResult<()> {
         let challenge = self.challenge_bytes()?;
@@ -57,7 +57,7 @@ impl<'a, H, U> PoWChallenge for VerifierState<'a, H, U>
 where
     U: Unit,
     H: DuplexSpongeInterface<U>,
-    VerifierState<'a, H, U>: UnitToBytesDeserialize + UnitToBytes,
+    VerifierState<'a, H, U>: BytesToUnitDeserialize + UnitToBytes,
 {
     fn challenge_pow<S: PowStrategy>(&mut self, bits: f64) -> ProofResult<()> {
         let challenge = self.challenge_bytes()?;

--- a/spongefish/examples/bulletproof.rs
+++ b/spongefish/examples/bulletproof.rs
@@ -14,9 +14,9 @@ use ark_ff::Field;
 use ark_std::log2;
 use rand::rngs::OsRng;
 use spongefish::codecs::arkworks_algebra::{
-    CommonGroupToUnit, DeserializeField, DeserializeGroup, DomainSeparator, FieldDomainSeparator,
-    FieldToUnit, GroupDomainSeparator, GroupToUnit, ProofError, ProofResult, ProverState,
-    UnitToField, VerifierState,
+    CommonGroupToUnit, DomainSeparator, FieldDomainSeparator, FieldToUnitDeserialize,
+    FieldToUnitSerialize, GroupDomainSeparator, GroupToUnitDeserialize, GroupToUnitSerialize,
+    ProofError, ProofResult, ProverState, UnitToField, VerifierState,
 };
 
 /// The IO Pattern of a bulleproof.
@@ -56,7 +56,7 @@ fn prove<'a, G: CurveGroup>(
     witness: (&[G::ScalarField], &[G::ScalarField]),
 ) -> ProofResult<&'a [u8]>
 where
-    ProverState: GroupToUnit<G> + UnitToField<G::ScalarField>,
+    ProverState: GroupToUnitSerialize<G> + UnitToField<G::ScalarField>,
 {
     assert_eq!(witness.0.len(), witness.1.len());
 
@@ -107,7 +107,7 @@ fn verify<G: CurveGroup>(
     statement: &G,
 ) -> ProofResult<()>
 where
-    for<'a> VerifierState<'a>: DeserializeGroup<G> + UnitToField<G::ScalarField>,
+    for<'a> VerifierState<'a>: GroupToUnitDeserialize<G> + UnitToField<G::ScalarField>,
 {
     let mut g = generators.0.to_vec();
     let mut h = generators.1.to_vec();

--- a/spongefish/examples/schnorr.rs
+++ b/spongefish/examples/schnorr.rs
@@ -22,9 +22,9 @@ use ark_ec::{CurveGroup, PrimeGroup};
 use ark_std::UniformRand;
 use rand::rngs::OsRng;
 use spongefish::codecs::arkworks_algebra::{
-    CommonGroupToUnit, DeserializeField, DeserializeGroup, DomainSeparator, DuplexSpongeInterface,
-    FieldDomainSeparator, FieldToUnit, GroupDomainSeparator, GroupToUnit, ProofError, ProofResult,
-    ProverState, UnitToField, VerifierState,
+    CommonGroupToUnit, DomainSeparator, DuplexSpongeInterface, FieldDomainSeparator,
+    FieldToUnitDeserialize, FieldToUnitSerialize, GroupDomainSeparator, GroupToUnitDeserialize,
+    GroupToUnitSerialize, ProofError, ProofResult, ProverState, UnitToField, VerifierState,
 };
 
 /// Extend the IO pattern with the Schnorr protocol.
@@ -90,7 +90,7 @@ fn prove<H, G>(
 where
     H: DuplexSpongeInterface,
     G: CurveGroup,
-    ProverState<H>: GroupToUnit<G> + UnitToField<G::ScalarField>,
+    ProverState<H>: GroupToUnitSerialize<G> + UnitToField<G::ScalarField>,
 {
     // `ProverState` types implement a cryptographically-secure random number generator that is tied to the protocol transcript
     // and that can be accessed via the `rng()` function.
@@ -129,8 +129,9 @@ fn verify<G, H>(
 where
     G: CurveGroup,
     H: DuplexSpongeInterface,
-    for<'a> VerifierState<'a, H>:
-        DeserializeGroup<G> + DeserializeField<G::ScalarField> + UnitToField<G::ScalarField>,
+    for<'a> VerifierState<'a, H>: GroupToUnitDeserialize<G>
+        + FieldToUnitDeserialize<G::ScalarField>
+        + UnitToField<G::ScalarField>,
 {
     // Read the protocol from the transcript.
     // [[Side note:

--- a/spongefish/src/codecs/arkworks_algebra/deserialize.rs
+++ b/spongefish/src/codecs/arkworks_algebra/deserialize.rs
@@ -6,7 +6,7 @@ use ark_ff::{Fp, FpConfig};
 use ark_serialize::CanonicalDeserialize;
 
 use super::{DeserializeField, DeserializeGroup};
-use crate::traits::{UnitToBytesDeserialize, UnitTranscript};
+use crate::traits::{BytesToUnitDeserialize, UnitTranscript};
 use crate::{DuplexSpongeInterface, ProofResult, VerifierState};
 
 impl<F, H> DeserializeField<F> for VerifierState<'_, H>

--- a/spongefish/src/codecs/arkworks_algebra/deserialize.rs
+++ b/spongefish/src/codecs/arkworks_algebra/deserialize.rs
@@ -5,11 +5,11 @@ use ark_ff::Field;
 use ark_ff::{Fp, FpConfig};
 use ark_serialize::CanonicalDeserialize;
 
-use super::{DeserializeField, DeserializeGroup};
+use super::{FieldToUnitDeserialize, GroupToUnitDeserialize};
 use crate::traits::{BytesToUnitDeserialize, UnitTranscript};
 use crate::{DuplexSpongeInterface, ProofResult, VerifierState};
 
-impl<F, H> DeserializeField<F> for VerifierState<'_, H>
+impl<F, H> FieldToUnitDeserialize<F> for VerifierState<'_, H>
 where
     F: Field,
     H: DuplexSpongeInterface,
@@ -25,7 +25,7 @@ where
     }
 }
 
-impl<G, H> DeserializeGroup<G> for VerifierState<'_, H>
+impl<G, H> GroupToUnitDeserialize<G> for VerifierState<'_, H>
 where
     G: CurveGroup,
     H: DuplexSpongeInterface,
@@ -42,7 +42,7 @@ where
     }
 }
 
-impl<H, C, const N: usize> DeserializeField<Fp<C, N>> for VerifierState<'_, H, Fp<C, N>>
+impl<H, C, const N: usize> FieldToUnitDeserialize<Fp<C, N>> for VerifierState<'_, H, Fp<C, N>>
 where
     C: FpConfig<N>,
     H: DuplexSpongeInterface<Fp<C, N>>,
@@ -53,7 +53,8 @@ where
     }
 }
 
-impl<P, H, C, const N: usize> DeserializeGroup<EdwardsCurve<P>> for VerifierState<'_, H, Fp<C, N>>
+impl<P, H, C, const N: usize> GroupToUnitDeserialize<EdwardsCurve<P>>
+    for VerifierState<'_, H, Fp<C, N>>
 where
     C: FpConfig<N>,
     H: DuplexSpongeInterface<Fp<C, N>>,
@@ -69,7 +70,7 @@ where
     }
 }
 
-impl<P, H, C, const N: usize> DeserializeGroup<SWCurve<P>> for VerifierState<'_, H, Fp<C, N>>
+impl<P, H, C, const N: usize> GroupToUnitDeserialize<SWCurve<P>> for VerifierState<'_, H, Fp<C, N>>
 where
     C: FpConfig<N>,
     H: DuplexSpongeInterface<Fp<C, N>>,

--- a/spongefish/src/codecs/arkworks_algebra/mod.rs
+++ b/spongefish/src/codecs/arkworks_algebra/mod.rs
@@ -39,7 +39,7 @@
 //!     x: G::ScalarField,
 //! ) -> ProofResult<&[u8]>
 //! where
-//!     ProverState: GroupToUnit<G> + UnitToBytes,
+//!     ProverState: GroupToUnitSerialize<G> + UnitToBytes,
 //! {
 //!     let k = G::ScalarField::rand(prover_state.rng());
 //!     prover_state.add_points(&[G::generator() * k])?;
@@ -101,7 +101,7 @@
 //!     H: DuplexSpongeInterface<U>,
 //!     // ... and the prover to be able to absorb and squeeze elements from the group and the base field.
 //!     // (normally would be the ScalarField but this is to make it work nicely with algebraic hashes)
-//!     ProverState<H, U>: GroupToUnit<G> + FieldToUnit<G::BaseField> + UnitToBytes,
+//!     ProverState<H, U>: GroupToUnitSerialize<G> + FieldToUnitSerialize<G::BaseField> + UnitToBytes,
 //! {
 //!     let k = G::ScalarField::rand(prover_state.rng());
 //!     prover_state.add_points(&[G::generator() * k])?;
@@ -164,14 +164,14 @@ pub fn swap_field<F1: ark_ff::PrimeField, F2: ark_ff::PrimeField>(a_f1: F1) -> P
 // }
 // pub trait PairingWriter<P: ark_ec::pairing::Pairing> {
 //     fn add_g1_points(&mut self, input: &[P::G1]) -> crate::ProofResult<()> {
-//         GroupToUnit::<P::G1>::add_points(self, input)
+//         GroupToUnitSerialize::<P::G1>::add_points(self, input)
 //     }
 
 //     fn add_g2_points(&mut self, input: &[P::G2]) -> crate::ProofResult<()> {
-//         GroupToUnit::<P::G2>::add_points(self, input)
+//         GroupToUnitSerialize::<P::G2>::add_points(self, input)
 //     }
 // }
 
 // impl<'a, P: ark_ec::pairing::Pairing, H, U> PairingWriter<P> for VerifierState<'a, H, U> where
 // U: Unit, H: DuplexSpongeInterface<U>,
-// VerifierState<'a, H, U>:  GroupToUnit<P::G1> + GroupToUnit<P::G2>  {}
+// VerifierState<'a, H, U>:  GroupToUnitSerialize<P::G1> + GroupToUnitSerialize<P::G2>  {}

--- a/spongefish/src/codecs/arkworks_algebra/prover_messages.rs
+++ b/spongefish/src/codecs/arkworks_algebra/prover_messages.rs
@@ -3,13 +3,13 @@ use ark_ff::{Field, Fp, FpConfig};
 use ark_serialize::CanonicalSerialize;
 use rand::{CryptoRng, RngCore};
 
-use super::{CommonFieldToUnit, CommonGroupToUnit, FieldToUnit, GroupToUnit};
+use super::{CommonFieldToUnit, CommonGroupToUnit, FieldToUnitSerialize, GroupToUnitSerialize};
 use crate::{
     BytesToUnitDeserialize, BytesToUnitSerialize, CommonUnitToBytes, DomainSeparatorMismatch,
     DuplexSpongeInterface, ProofResult, ProverState, Unit, UnitTranscript, VerifierState,
 };
 
-impl<F: Field, H: DuplexSpongeInterface, R: RngCore + CryptoRng> FieldToUnit<F>
+impl<F: Field, H: DuplexSpongeInterface, R: RngCore + CryptoRng> FieldToUnitSerialize<F>
     for ProverState<H, u8, R>
 {
     fn add_scalars(&mut self, input: &[F]) -> ProofResult<()> {
@@ -24,7 +24,7 @@ impl<
         H: DuplexSpongeInterface<Fp<C, N>>,
         R: RngCore + CryptoRng,
         const N: usize,
-    > FieldToUnit<Fp<C, N>> for ProverState<H, Fp<C, N>, R>
+    > FieldToUnitSerialize<Fp<C, N>> for ProverState<H, Fp<C, N>, R>
 {
     fn add_scalars(&mut self, input: &[Fp<C, N>]) -> ProofResult<()> {
         self.public_units(input)?;
@@ -35,7 +35,7 @@ impl<
     }
 }
 
-impl<G, H, R> GroupToUnit<G> for ProverState<H, u8, R>
+impl<G, H, R> GroupToUnitSerialize<G> for ProverState<H, u8, R>
 where
     G: CurveGroup,
     H: DuplexSpongeInterface,
@@ -49,13 +49,13 @@ where
     }
 }
 
-impl<G, H, R, C: FpConfig<N>, C2: FpConfig<N>, const N: usize> GroupToUnit<G>
+impl<G, H, R, C: FpConfig<N>, C2: FpConfig<N>, const N: usize> GroupToUnitSerialize<G>
     for ProverState<H, Fp<C, N>, R>
 where
     G: CurveGroup<BaseField = Fp<C2, N>>,
     H: DuplexSpongeInterface<Fp<C, N>>,
     R: RngCore + CryptoRng,
-    Self: CommonGroupToUnit<G> + FieldToUnit<G::BaseField>,
+    Self: CommonGroupToUnit<G> + FieldToUnitSerialize<G::BaseField>,
 {
     fn add_points(&mut self, input: &[G]) -> ProofResult<()> {
         self.public_points(input).map(|_| ())?;

--- a/spongefish/src/codecs/arkworks_algebra/prover_messages.rs
+++ b/spongefish/src/codecs/arkworks_algebra/prover_messages.rs
@@ -6,7 +6,7 @@ use rand::{CryptoRng, RngCore};
 use super::{CommonFieldToUnit, CommonGroupToUnit, FieldToUnit, GroupToUnit};
 use crate::{
     CommonUnitToBytes, DomainSeparatorMismatch, DuplexSpongeInterface, ProofResult, ProverState,
-    Unit, UnitToBytesDeserialize, UnitToBytesSerialize, UnitTranscript, VerifierState,
+    Unit, BytesToUnitDeserialize, BytesToUnitSerialize, UnitTranscript, VerifierState,
 };
 
 impl<F: Field, H: DuplexSpongeInterface, R: RngCore + CryptoRng> FieldToUnit<F>
@@ -66,7 +66,7 @@ where
     }
 }
 
-impl<H, R, C, const N: usize> UnitToBytesSerialize for ProverState<H, Fp<C, N>, R>
+impl<H, R, C, const N: usize> BytesToUnitSerialize for ProverState<H, Fp<C, N>, R>
 where
     H: DuplexSpongeInterface<Fp<C, N>>,
     C: FpConfig<N>,
@@ -79,7 +79,7 @@ where
     }
 }
 
-impl<H, C, const N: usize> UnitToBytesDeserialize for VerifierState<'_, H, Fp<C, N>>
+impl<H, C, const N: usize> BytesToUnitDeserialize for VerifierState<'_, H, Fp<C, N>>
 where
     H: DuplexSpongeInterface<Fp<C, N>>,
     C: FpConfig<N>,

--- a/spongefish/src/codecs/arkworks_algebra/prover_messages.rs
+++ b/spongefish/src/codecs/arkworks_algebra/prover_messages.rs
@@ -5,8 +5,8 @@ use rand::{CryptoRng, RngCore};
 
 use super::{CommonFieldToUnit, CommonGroupToUnit, FieldToUnit, GroupToUnit};
 use crate::{
-    CommonUnitToBytes, DomainSeparatorMismatch, DuplexSpongeInterface, ProofResult, ProverState,
-    Unit, BytesToUnitDeserialize, BytesToUnitSerialize, UnitTranscript, VerifierState,
+    BytesToUnitDeserialize, BytesToUnitSerialize, CommonUnitToBytes, DomainSeparatorMismatch,
+    DuplexSpongeInterface, ProofResult, ProverState, Unit, UnitTranscript, VerifierState,
 };
 
 impl<F: Field, H: DuplexSpongeInterface, R: RngCore + CryptoRng> FieldToUnit<F>

--- a/spongefish/src/codecs/arkworks_algebra/tests.rs
+++ b/spongefish/src/codecs/arkworks_algebra/tests.rs
@@ -1,6 +1,6 @@
 use crate::{
     ByteDomainSeparator, DefaultHash, DomainSeparator, DuplexSpongeInterface, ProofResult, Unit,
-    UnitToBytes, UnitToBytesDeserialize, UnitToBytesSerialize, UnitTranscript,
+    UnitToBytes, BytesToUnitDeserialize, BytesToUnitSerialize, UnitTranscript,
 };
 
 use ark_ff::Field;

--- a/spongefish/src/codecs/arkworks_algebra/tests.rs
+++ b/spongefish/src/codecs/arkworks_algebra/tests.rs
@@ -1,6 +1,6 @@
 use crate::{
-    ByteDomainSeparator, DefaultHash, DomainSeparator, DuplexSpongeInterface, ProofResult, Unit,
-    UnitToBytes, BytesToUnitDeserialize, BytesToUnitSerialize, UnitTranscript,
+    ByteDomainSeparator, BytesToUnitDeserialize, BytesToUnitSerialize, DefaultHash,
+    DomainSeparator, DuplexSpongeInterface, ProofResult, Unit, UnitToBytes, UnitTranscript,
 };
 
 use ark_ff::Field;

--- a/spongefish/src/codecs/arkworks_algebra/tests.rs
+++ b/spongefish/src/codecs/arkworks_algebra/tests.rs
@@ -41,7 +41,9 @@ where
 }
 
 fn test_arkworks_end_to_end<F: Field, H: DuplexSpongeInterface>() -> ProofResult<()> {
-    use crate::codecs::arkworks_algebra::{DeserializeField, FieldToUnit, UnitToField};
+    use crate::codecs::arkworks_algebra::{
+        FieldToUnitDeserialize, FieldToUnitSerialize, UnitToField,
+    };
     use rand::Rng;
 
     let mut rng = ark_std::test_rng();

--- a/spongefish/src/codecs/tests.rs
+++ b/spongefish/src/codecs/tests.rs
@@ -112,16 +112,20 @@ where
     assert_eq!(ark_domsep.as_bytes(), group_domsep.as_bytes());
 
     // Check that scalars absorption leads to the same transcript.
-    codecs::arkworks_algebra::FieldToUnit::add_scalars(&mut ark_prover, &[ark_scalar]).unwrap();
+    codecs::arkworks_algebra::FieldToUnitSerialize::add_scalars(&mut ark_prover, &[ark_scalar])
+        .unwrap();
     ark_prover.fill_challenge_bytes(&mut ark_chal).unwrap();
-    codecs::zkcrypto_group::FieldToUnit::add_scalars(&mut group_prover, &[group_scalar]).unwrap();
+    codecs::zkcrypto_group::FieldToUnitSerialize::add_scalars(&mut group_prover, &[group_scalar])
+        .unwrap();
     group_prover.fill_challenge_bytes(&mut group_chal).unwrap();
     assert_eq!(ark_chal, group_chal);
 
     // Check that points absorption leads to the same transcript.
-    codecs::arkworks_algebra::GroupToUnit::add_points(&mut ark_prover, &[ark_point]).unwrap();
+    codecs::arkworks_algebra::GroupToUnitSerialize::add_points(&mut ark_prover, &[ark_point])
+        .unwrap();
     ark_prover.fill_challenge_bytes(&mut ark_chal).unwrap();
-    codecs::zkcrypto_group::GroupToUnit::add_points(&mut group_prover, &[group_point]).unwrap();
+    codecs::zkcrypto_group::GroupToUnitSerialize::add_points(&mut group_prover, &[group_point])
+        .unwrap();
     group_prover.fill_challenge_bytes(&mut group_chal).unwrap();
     assert_eq!(ark_chal, group_chal);
 

--- a/spongefish/src/codecs/traits.rs
+++ b/spongefish/src/codecs/traits.rs
@@ -28,7 +28,7 @@ macro_rules! field_traits {
         }
 
         /// Add field elements to the protocol transcript.
-        pub trait FieldToUnit<F: $Field>: CommonFieldToUnit<F> {
+        pub trait FieldToUnitSerialize<F: $Field>: CommonFieldToUnit<F> {
             fn add_scalars(&mut self, input: &[F]) -> crate::ProofResult<()>;
         }
 
@@ -36,7 +36,7 @@ macro_rules! field_traits {
         ///
         /// The implementation of this trait **MUST** ensure that the field elements
         /// are correct encodings.
-        pub trait DeserializeField<F: $Field>: CommonFieldToUnit<F> {
+        pub trait FieldToUnitDeserialize<F: $Field>: CommonFieldToUnit<F> {
             fn fill_next_scalars(&mut self, output: &mut [F]) -> crate::ProofResult<()>;
 
             fn next_scalars<const N: usize>(&mut self) -> crate::ProofResult<[F; N]> {
@@ -57,7 +57,7 @@ macro_rules! group_traits {
         }
 
         /// Adds a new prover message consisting of an EC element.
-        pub trait GroupToUnit<G: $Group>: CommonGroupToUnit<G> {
+        pub trait GroupToUnitSerialize<G: $Group>: CommonGroupToUnit<G> {
             fn add_points(&mut self, input: &[G]) -> $crate::ProofResult<()>;
         }
 
@@ -65,7 +65,7 @@ macro_rules! group_traits {
         ///
         /// The implementation of this trait **MUST** ensure that the points decoded are
         /// valid group elements.
-        pub trait DeserializeGroup<G: $Group + Default> {
+        pub trait GroupToUnitDeserialize<G: $Group + Default> {
             /// Deserialize group elements from the protocol transcript into `output`.
             fn fill_next_points(&mut self, output: &mut [G]) -> $crate::ProofResult<()>;
 

--- a/spongefish/src/codecs/zkcrypto_group/deserialize.rs
+++ b/spongefish/src/codecs/zkcrypto_group/deserialize.rs
@@ -1,5 +1,5 @@
 use super::DeserializeField;
-use crate::{DuplexSpongeInterface, ProofError, UnitToBytesDeserialize, VerifierState};
+use crate::{DuplexSpongeInterface, ProofError, BytesToUnitDeserialize, VerifierState};
 use group::ff::PrimeField;
 
 impl<F, H, const N: usize> DeserializeField<F> for VerifierState<'_, H>

--- a/spongefish/src/codecs/zkcrypto_group/deserialize.rs
+++ b/spongefish/src/codecs/zkcrypto_group/deserialize.rs
@@ -1,8 +1,8 @@
-use super::DeserializeField;
+use super::FieldToUnitDeserialize;
 use crate::{BytesToUnitDeserialize, DuplexSpongeInterface, ProofError, VerifierState};
 use group::ff::PrimeField;
 
-impl<F, H, const N: usize> DeserializeField<F> for VerifierState<'_, H>
+impl<F, H, const N: usize> FieldToUnitDeserialize<F> for VerifierState<'_, H>
 where
     H: DuplexSpongeInterface,
     F: PrimeField<Repr = [u8; N]>,

--- a/spongefish/src/codecs/zkcrypto_group/deserialize.rs
+++ b/spongefish/src/codecs/zkcrypto_group/deserialize.rs
@@ -1,5 +1,5 @@
 use super::DeserializeField;
-use crate::{DuplexSpongeInterface, ProofError, BytesToUnitDeserialize, VerifierState};
+use crate::{BytesToUnitDeserialize, DuplexSpongeInterface, ProofError, VerifierState};
 use group::ff::PrimeField;
 
 impl<F, H, const N: usize> DeserializeField<F> for VerifierState<'_, H>

--- a/spongefish/src/codecs/zkcrypto_group/prover_messages.rs
+++ b/spongefish/src/codecs/zkcrypto_group/prover_messages.rs
@@ -3,7 +3,7 @@ use rand::{CryptoRng, RngCore};
 
 use super::{CommonFieldToUnit, CommonGroupToUnit, FieldToUnit, GroupToUnit};
 use crate::{
-    CommonUnitToBytes, DuplexSpongeInterface, ProofResult, ProverState, BytesToUnitSerialize,
+    BytesToUnitSerialize, CommonUnitToBytes, DuplexSpongeInterface, ProofResult, ProverState,
 };
 
 impl<F, H, R> FieldToUnit<F> for ProverState<H, u8, R>

--- a/spongefish/src/codecs/zkcrypto_group/prover_messages.rs
+++ b/spongefish/src/codecs/zkcrypto_group/prover_messages.rs
@@ -3,7 +3,7 @@ use rand::{CryptoRng, RngCore};
 
 use super::{CommonFieldToUnit, CommonGroupToUnit, FieldToUnit, GroupToUnit};
 use crate::{
-    CommonUnitToBytes, DuplexSpongeInterface, ProofResult, ProverState, UnitToBytesSerialize,
+    CommonUnitToBytes, DuplexSpongeInterface, ProofResult, ProverState, BytesToUnitSerialize,
 };
 
 impl<F, H, R> FieldToUnit<F> for ProverState<H, u8, R>

--- a/spongefish/src/codecs/zkcrypto_group/prover_messages.rs
+++ b/spongefish/src/codecs/zkcrypto_group/prover_messages.rs
@@ -1,12 +1,12 @@
 use group::{ff::PrimeField, Group, GroupEncoding};
 use rand::{CryptoRng, RngCore};
 
-use super::{CommonFieldToUnit, CommonGroupToUnit, FieldToUnit, GroupToUnit};
+use super::{CommonFieldToUnit, CommonGroupToUnit, FieldToUnitSerialize, GroupToUnitSerialize};
 use crate::{
     BytesToUnitSerialize, CommonUnitToBytes, DuplexSpongeInterface, ProofResult, ProverState,
 };
 
-impl<F, H, R> FieldToUnit<F> for ProverState<H, u8, R>
+impl<F, H, R> FieldToUnitSerialize<F> for ProverState<H, u8, R>
 where
     F: PrimeField,
     H: DuplexSpongeInterface,
@@ -37,7 +37,7 @@ where
     }
 }
 
-impl<G, H, R> GroupToUnit<G> for ProverState<H, u8, R>
+impl<G, H, R> GroupToUnitSerialize<G> for ProverState<H, u8, R>
 where
     G: Group + GroupEncoding,
     G::Repr: AsRef<[u8]>,

--- a/spongefish/src/duplex_sponge/tests.rs
+++ b/spongefish/src/duplex_sponge/tests.rs
@@ -3,7 +3,7 @@ use rand::RngCore;
 use crate::duplex_sponge::legacy::DigestBridge;
 use crate::permutations::keccak::Keccak;
 use crate::{
-    UnitToBytes, CommonUnitToBytes, UnitToBytesDeserialize, UnitToBytesSerialize, DuplexInterface, DomainSeparator,
+    UnitToBytes, CommonUnitToBytes, BytesToUnitDeserialize, BytesToUnitSerialize, DuplexInterface, DomainSeparator,
     ProverState, StatefulHashObject,
 };
 
@@ -159,7 +159,7 @@ fn test_prover_empty_absorb() {
 /// Absorbs and squeeze over byte-Units should be streamable.
 fn test_streaming_absorb_and_squeeze<H: DuplexInterface>()
 where
-    ProverState<H>: UnitToBytesSerialize + UnitToBytes,
+    ProverState<H>: BytesToUnitSerialize + UnitToBytes,
 {
     let bytes = b"yellow submarine";
 

--- a/spongefish/src/prover.rs
+++ b/spongefish/src/prover.rs
@@ -1,7 +1,7 @@
 use rand::{CryptoRng, RngCore};
 
 use crate::duplex_sponge::Unit;
-use crate::{DomainSeparator, HashStateWithInstructions, BytesToUnitSerialize, UnitTranscript};
+use crate::{BytesToUnitSerialize, DomainSeparator, HashStateWithInstructions, UnitTranscript};
 
 use super::duplex_sponge::DuplexSpongeInterface;
 use super::keccak::Keccak;

--- a/spongefish/src/prover.rs
+++ b/spongefish/src/prover.rs
@@ -1,7 +1,7 @@
 use rand::{CryptoRng, RngCore};
 
 use crate::duplex_sponge::Unit;
-use crate::{DomainSeparator, HashStateWithInstructions, UnitToBytesSerialize, UnitTranscript};
+use crate::{DomainSeparator, HashStateWithInstructions, BytesToUnitSerialize, UnitTranscript};
 
 use super::duplex_sponge::DuplexSpongeInterface;
 use super::keccak::Keccak;
@@ -124,7 +124,7 @@ where
     /// and used to re-seed the prover's random number generator.
     ///
     /// ```
-    /// use spongefish::{DomainSeparator, DefaultHash, UnitToBytesSerialize};
+    /// use spongefish::{DomainSeparator, DefaultHash, BytesToUnitSerialize};
     ///
     /// let domain_separator = DomainSeparator::<DefaultHash>::new("📝").absorb(20, "how not to make pasta 🤌");
     /// let mut prover_state = domain_separator.to_prover_state();
@@ -228,7 +228,7 @@ where
     }
 }
 
-impl<H, R> UnitToBytesSerialize for ProverState<H, u8, R>
+impl<H, R> BytesToUnitSerialize for ProverState<H, u8, R>
 where
     H: DuplexSpongeInterface<u8>,
     R: RngCore + CryptoRng,

--- a/spongefish/src/tests.rs
+++ b/spongefish/src/tests.rs
@@ -4,7 +4,7 @@ use crate::duplex_sponge::legacy::DigestBridge;
 use crate::keccak::Keccak;
 use crate::{
     CommonUnitToBytes, DomainSeparator, DuplexSpongeInterface, HashStateWithInstructions,
-    ProverState, UnitToBytes, UnitToBytesDeserialize, UnitToBytesSerialize,
+    ProverState, UnitToBytes, BytesToUnitDeserialize, BytesToUnitSerialize,
 };
 
 type Sha2 = DigestBridge<sha2::Sha256>;
@@ -171,7 +171,7 @@ fn test_prover_empty_absorb() {
 /// Absorbs and squeeze over byte-Units should be streamable.
 fn test_streaming_absorb_and_squeeze<H: DuplexSpongeInterface>()
 where
-    ProverState<H>: UnitToBytesSerialize + UnitToBytes,
+    ProverState<H>: BytesToUnitSerialize + UnitToBytes,
 {
     let bytes = b"yellow submarine";
 

--- a/spongefish/src/tests.rs
+++ b/spongefish/src/tests.rs
@@ -3,8 +3,8 @@ use rand::RngCore;
 use crate::duplex_sponge::legacy::DigestBridge;
 use crate::keccak::Keccak;
 use crate::{
-    CommonUnitToBytes, DomainSeparator, DuplexSpongeInterface, HashStateWithInstructions,
-    ProverState, UnitToBytes, BytesToUnitDeserialize, BytesToUnitSerialize,
+    BytesToUnitDeserialize, BytesToUnitSerialize, CommonUnitToBytes, DomainSeparator,
+    DuplexSpongeInterface, HashStateWithInstructions, ProverState, UnitToBytes,
 };
 
 type Sha2 = DigestBridge<sha2::Sha256>;

--- a/spongefish/src/traits.rs
+++ b/spongefish/src/traits.rs
@@ -45,7 +45,7 @@ pub trait UnitToBytes {
 /// We point the curious reader to the documentation of [`CommonUnitToBytes`] and [`UnitToBytes`] for more details.
 pub trait ByteTranscript: CommonUnitToBytes + UnitToBytes {}
 
-pub trait UnitToBytesDeserialize {
+pub trait BytesToUnitDeserialize {
     fn fill_next_bytes(&mut self, input: &mut [u8]) -> Result<(), DomainSeparatorMismatch>;
 
     fn next_bytes<const N: usize>(&mut self) -> Result<[u8; N], DomainSeparatorMismatch> {
@@ -54,7 +54,7 @@ pub trait UnitToBytesDeserialize {
     }
 }
 
-pub trait UnitToBytesSerialize {
+pub trait BytesToUnitSerialize {
     fn add_bytes(&mut self, input: &[u8]) -> Result<(), DomainSeparatorMismatch>;
 }
 

--- a/spongefish/src/verifier.rs
+++ b/spongefish/src/verifier.rs
@@ -2,7 +2,7 @@ use crate::domain_separator::DomainSeparator;
 use crate::duplex_sponge::{DuplexSpongeInterface, Unit};
 use crate::errors::DomainSeparatorMismatch;
 use crate::sho::HashStateWithInstructions;
-use crate::traits::{UnitToBytesDeserialize, UnitTranscript};
+use crate::traits::{BytesToUnitDeserialize, UnitTranscript};
 use crate::DefaultHash;
 
 /// [`VerifierState`] is the verifier state.
@@ -88,7 +88,7 @@ impl<H: DuplexSpongeInterface<U>, U: Unit> core::fmt::Debug for VerifierState<'_
     }
 }
 
-impl<H: DuplexSpongeInterface<u8>> UnitToBytesDeserialize for VerifierState<'_, H, u8> {
+impl<H: DuplexSpongeInterface<u8>> BytesToUnitDeserialize for VerifierState<'_, H, u8> {
     /// Read the next `input.len()` bytes from the NARG string and return them.
     #[inline]
     fn fill_next_bytes(&mut self, input: &mut [u8]) -> Result<(), DomainSeparatorMismatch> {


### PR DESCRIPTION
Intuitively, we are taking some bytes (either from the prover or the argument string) and converting them to units before adding them into the sponge.