### PR TITLE
Use zerocopy to do safe transmute between `[u8;200]` and `[u64;25]`.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -62,6 +62,7 @@ rand = "0.8.5"
 rayon = "1.10.0"
 sha2 = "0.10.7"
 sha3 = "0.10.8"
+zerocopy = "0.8"
 zeroize = "1.8.1"
 
 

--- a/spongefish/Cargo.toml
+++ b/spongefish/Cargo.toml
@@ -13,6 +13,7 @@ license = "BSD-3-Clause"
 workspace = true
 
 [dependencies]
+zerocopy = { workspace = true, features = ["std", "derive"] }
 zeroize = { workspace = true, features = ["zeroize_derive"] }
 rand = { workspace = true, features = ["getrandom"] }
 digest = { workspace = true }

--- a/spongefish/Cargo.toml
+++ b/spongefish/Cargo.toml
@@ -13,7 +13,7 @@ license = "BSD-3-Clause"
 workspace = true
 
 [dependencies]
-zerocopy = { workspace = true, features = ["std", "derive"] }
+zerocopy = { workspace = true }
 zeroize = { workspace = true, features = ["zeroize_derive"] }
 rand = { workspace = true, features = ["getrandom"] }
 digest = { workspace = true }

--- a/spongefish/src/duplex_sponge/mod.rs
+++ b/spongefish/src/duplex_sponge/mod.rs
@@ -60,7 +60,7 @@ pub trait Permutation: Zeroize + Default + Clone + AsRef<[Self::U]> + AsMut<[Sel
 }
 
 /// A cryptographic sponge.
-#[derive(Clone, Default, Zeroize, ZeroizeOnDrop)]
+#[derive(Clone, PartialEq, Eq, Default, Zeroize, ZeroizeOnDrop)]
 pub struct DuplexSponge<C: Permutation> {
     permutation: C,
     absorb_pos: usize,

--- a/spongefish/src/keccak.rs
+++ b/spongefish/src/keccak.rs
@@ -20,7 +20,7 @@ pub type Keccak = DuplexSponge<KeccakF1600>;
 
 /// Keccak permutation internal state: 25 64-bit words,
 /// or equivalently 200 bytes in little-endian order.
-#[derive(Clone, PartialEq, Eq, Zeroize, ZeroizeOnDrop)]
+#[derive(Clone, PartialEq, Eq, Default, Zeroize, ZeroizeOnDrop)]
 pub struct KeccakF1600([u64; 25]);
 
 impl Permutation for KeccakF1600 {
@@ -36,12 +36,6 @@ impl Permutation for KeccakF1600 {
 
     fn permute(&mut self) {
         keccak::f1600(&mut self.0);
-    }
-}
-
-impl Default for KeccakF1600 {
-    fn default() -> Self {
-        Self([0u64; 25])
     }
 }
 

--- a/spongefish/src/keccak.rs
+++ b/spongefish/src/keccak.rs
@@ -2,55 +2,66 @@
 //! Despite internally we use the same permutation function,
 //! we build a duplex sponge in overwrite mode
 //! on the top of it using the `DuplexSponge` trait.
+use std::fmt::Debug;
+
+use zerocopy::IntoBytes;
 use zeroize::{Zeroize, ZeroizeOnDrop};
 
 use crate::duplex_sponge::{DuplexSponge, Permutation};
 
 /// A duplex sponge based on the permutation [`keccak::f1600`]
 /// using [`DuplexSponge`].
-pub type Keccak = DuplexSponge<AlignedKeccakF1600>;
+///
+/// **Warning**: This function is not SHA3.
+/// Despite internally we use the same permutation function,
+/// we build a duplex sponge in overwrite mode
+/// on the top of it using the `DuplexSponge` trait.
+pub type Keccak = DuplexSponge<KeccakF1600>;
 
-fn transmute_state(st: &mut AlignedKeccakF1600) -> &mut [u64; 25] {
-    unsafe { &mut *std::ptr::from_mut::<AlignedKeccakF1600>(st).cast::<[u64; 25]>() }
-}
+/// Keccak permutation internal state: 25 64-bit words,
+/// or equivalently 200 bytes in little-endian order.
+#[derive(Clone, PartialEq, Eq, Zeroize, ZeroizeOnDrop)]
+pub struct KeccakF1600([u64; 25]);
 
-/// This is a wrapper around 200-byte buffer that's always 8-byte aligned
-/// to make pointers to it safely convertible to pointers to [u64; 25]
-/// (since u64 words must be 8-byte aligned)
-#[derive(Clone, Zeroize, ZeroizeOnDrop)]
-#[repr(align(8))]
-pub struct AlignedKeccakF1600([u8; 200]);
-
-impl Permutation for AlignedKeccakF1600 {
+impl Permutation for KeccakF1600 {
     type U = u8;
     const N: usize = 136 + 64;
     const R: usize = 136;
 
-    fn new(tag: [u8; 32]) -> Self {
+    fn new(iv: [u8; 32]) -> Self {
         let mut state = Self::default();
-        state.0[Self::R..Self::R + 32].copy_from_slice(&tag);
+        state.as_mut()[Self::R..Self::R + 32].copy_from_slice(&iv);
         state
     }
 
     fn permute(&mut self) {
-        keccak::f1600(transmute_state(self));
+        keccak::f1600(&mut self.0);
     }
 }
 
-impl Default for AlignedKeccakF1600 {
+impl Default for KeccakF1600 {
     fn default() -> Self {
-        Self([0u8; Self::N])
+        Self([0u64; 25])
     }
 }
 
-impl AsRef<[u8]> for AlignedKeccakF1600 {
+impl AsRef<[u8]> for KeccakF1600 {
     fn as_ref(&self) -> &[u8] {
-        &self.0
+        self.0.as_bytes()
     }
 }
 
-impl AsMut<[u8]> for AlignedKeccakF1600 {
+impl AsMut<[u8]> for KeccakF1600 {
     fn as_mut(&mut self) -> &mut [u8] {
-        &mut self.0
+        self.0.as_mut_bytes()
+    }
+}
+
+/// Censored version of Debug
+impl Debug for KeccakF1600 {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_tuple("AlignedKeccakF1600")
+            .field(&"<redacted>")
+            .finish()
     }
 }


### PR DESCRIPTION
Use zerocopy to do safe transmute between `[u8;200]` and `[u64;25]`.
Zerocopy does compile time checks on size, alignment and other constraints. Note that `zerocopy` was already a transitive dependency through `rand` and `arkworks`, so this doesn't grow the dependency set. 

Makes the internal state `[u64;25]` to avoid manual allignment annotation.

Adds `PartialEq, Eq, Debug` traits for convenience.

Consistently name `iv`.



