### PR TITLE
Add `pattern` module with stricter transcript recording

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -62,8 +62,8 @@ rand = "0.8.5"
 rayon = "1.10.0"
 sha2 = "0.10.7"
 sha3 = "0.10.8"
+thiserror = "2.0.12"
 zeroize = "1.8.1"
-
 
 # Un-comment below for latest arkworks libraries.
 # [patch.crates-io]

--- a/spongefish/Cargo.toml
+++ b/spongefish/Cargo.toml
@@ -25,7 +25,7 @@ ark-ec = { workspace = true, optional = true }
 ark-serialize = { workspace = true, features = ["std"], optional = true }
 group = { workspace = true, optional = true }
 hex = { workspace = true }
-thiserror.workspace = true
+thiserror = { workspace = true }
 
 [features]
 default = []

--- a/spongefish/Cargo.toml
+++ b/spongefish/Cargo.toml
@@ -24,6 +24,7 @@ ark-ec = { workspace = true, optional = true }
 ark-serialize = { workspace = true, features = ["std"], optional = true }
 group = { workspace = true, optional = true }
 hex = { workspace = true }
+thiserror.workspace = true
 
 [features]
 default = []

--- a/spongefish/Cargo.toml
+++ b/spongefish/Cargo.toml
@@ -26,6 +26,7 @@ ark-serialize = { workspace = true, features = ["std"], optional = true }
 group = { workspace = true, optional = true }
 hex = { workspace = true }
 thiserror = { workspace = true }
+sha3 = { workspace = true }
 
 [features]
 default = []

--- a/spongefish/src/lib.rs
+++ b/spongefish/src/lib.rs
@@ -148,6 +148,9 @@ mod sho;
 #[cfg(test)]
 mod tests;
 
+/// Proposed alternative domain separator
+pub mod pattern;
+
 /// Traits for byte support.
 pub mod traits;
 

--- a/spongefish/src/pattern/interaction.rs
+++ b/spongefish/src/pattern/interaction.rs
@@ -1,0 +1,175 @@
+use core::{any::type_name, fmt::Display};
+
+/// A single abstract prover-verifier interaction.
+#[derive(Clone, PartialEq, Eq, PartialOrd, Ord, Debug, Hash)]
+pub struct Interaction {
+    /// Hierarchical nesting of the interactions.
+    hierarchy: Hierarchy,
+    /// The kind of interaction.
+    kind: Kind,
+    /// A label identifying the purpose of the value.
+    label: Label,
+    /// The Rust name of the type of the value.
+    ///
+    /// We use [`core::any::type_name`] to verify value types intead of [`core::any::TypeID`] since
+    /// the latter only supports types with a `'static` lifetime. The downside of `type_name` is
+    /// that it is slightly less precise in that it can create more type collisions. But this is
+    /// acceptable here as it only serves as an additional check and as debug information.
+    type_name: &'static str,
+    /// Length of the value.
+    length: Length,
+}
+
+/// Labels for interactions.
+pub type Label = &'static str;
+
+/// Kinds of prover-verifier interactions
+#[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Debug, Hash)]
+pub enum Kind {
+    /// A protocol containing mixed interactions.
+    Protocol,
+    /// A public message prover and verifier agree on.
+    Public,
+    /// A message send in-band from prover to verifier.
+    Message,
+    /// A hint send out-of-band from prover to verifier.
+    Hint,
+    /// A challenge issued by the verifier.
+    Challenge,
+}
+
+/// Kinds of prover-verifier interactions
+#[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Debug, Hash)]
+pub enum Hierarchy {
+    /// A single interaction.
+    Atomic,
+    /// Start of a sub-protocol.
+    Begin,
+    /// End of a sub-protocol.
+    End,
+}
+
+/// Length of values involved in interactions.
+#[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Debug, Hash)]
+pub enum Length {
+    /// No length information.
+    None,
+    /// A single value.
+    Scalar,
+    /// A fixed number of values.
+    Fixed(usize),
+    /// A dynamic number of values.
+    Dynamic,
+}
+
+impl Interaction {
+    #[must_use]
+    pub fn new<T: ?Sized>(hierarchy: Hierarchy, kind: Kind, label: Label, length: Length) -> Self {
+        let type_name = type_name::<T>();
+        Self {
+            hierarchy,
+            kind,
+            label,
+            type_name,
+            length,
+        }
+    }
+
+    #[must_use]
+    pub const fn hierarchy(&self) -> Hierarchy {
+        self.hierarchy
+    }
+
+    #[must_use]
+    pub const fn kind(&self) -> Kind {
+        self.kind
+    }
+
+    /// Returns `true` if this is a `Hierarchy::End` that closes the provided
+    /// `Hierarchy::Begin`.
+    #[must_use]
+    pub(super) fn closes(&self, other: &Self) -> bool {
+        self.hierarchy == Hierarchy::End
+            && other.hierarchy == Hierarchy::Begin
+            && self.kind == other.kind
+            && self.label == other.label
+            && self.type_name == other.type_name
+            && self.length == other.length
+    }
+}
+
+impl Display for Interaction {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        if f.alternate() {
+            // Domain separator mode: stable unambiguous format.
+            write!(f, "{} {}", self.hierarchy, self.kind)?;
+            // Length prefixed strings for labels to disambiguate
+            write!(f, " {} {}", self.label.len(), self.label)?;
+            write!(f, " {}", self.length)
+            // Leave out type names for domain separators.
+        } else {
+            write!(
+                f,
+                "{} {} {} {} {}",
+                self.hierarchy, self.kind, self.label, self.length, self.type_name,
+            )
+        }
+    }
+}
+
+impl Display for Hierarchy {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::Atomic => write!(f, "Atomic"),
+            Self::Begin => write!(f, "Begin"),
+            Self::End => write!(f, "End"),
+        }
+    }
+}
+
+impl Display for Kind {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::Protocol => write!(f, "Protocol"),
+            Self::Public => write!(f, "Public"),
+            Self::Message => write!(f, "Message"),
+            Self::Hint => write!(f, "Hint"),
+            Self::Challenge => write!(f, "Challenge"),
+        }
+    }
+}
+
+impl Display for Length {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::None => write!(f, "None"),
+            Self::Scalar => write!(f, "Scalar"),
+            Self::Fixed(size) => write!(f, "Fixed({size})"),
+            Self::Dynamic => write!(f, "Dynamic"),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_sizes() {
+        dbg!(size_of::<Interaction>());
+        assert!(size_of::<Interaction>() < 80);
+    }
+
+    #[test]
+    fn test_domain_separator() {
+        let interaction = Interaction::new::<Vec<f64>>(
+            Hierarchy::Atomic,
+            Kind::Message,
+            "test-message",
+            Length::Scalar,
+        );
+        let result = format!("{interaction:#}");
+        let expected = "Atomic Message 12 test-message Scalar";
+        assert_eq!(result, expected);
+    }
+}

--- a/spongefish/src/pattern/interaction.rs
+++ b/spongefish/src/pattern/interaction.rs
@@ -11,7 +11,7 @@ pub struct Interaction {
     label: Label,
     /// The Rust name of the type of the value.
     ///
-    /// We use [`core::any::type_name`] to verify value types intead of [`core::any::TypeID`] since
+    /// We use [`core::any::type_name`] to verify value types instead of [`core::any::TypeID`] since
     /// the latter only supports types with a `'static` lifetime. The downside of `type_name` is
     /// that it is slightly less precise in that it can create more type collisions. But this is
     /// acceptable here as it only serves as an additional check and as debug information.

--- a/spongefish/src/pattern/interaction.rs
+++ b/spongefish/src/pattern/interaction.rs
@@ -155,12 +155,6 @@ mod tests {
     use super::*;
 
     #[test]
-    fn test_sizes() {
-        dbg!(size_of::<Interaction>());
-        assert!(size_of::<Interaction>() < 80);
-    }
-
-    #[test]
     fn test_domain_separator() {
         let interaction = Interaction::new::<Vec<f64>>(
             Hierarchy::Atomic,

--- a/spongefish/src/pattern/interaction_pattern.rs
+++ b/spongefish/src/pattern/interaction_pattern.rs
@@ -67,9 +67,9 @@ impl InteractionPattern {
     ///
     /// A valid transcript has:
     ///
-    /// - Matching [`InteractionHierachy::Begin`] and [`InteractionHierachy::End`] interactions
+    /// - Matching [`InteractionHierarchy::Begin`] and [`InteractionHierarchy::End`] interactions
     ///   creating a nested hierarchy.
-    /// - Nested interactions are the same [`InteractionKind`] as the last [`InteractionHierachy::Begin`] interaction, except for [`InteractionKind::Protocol`] which can contain any [`InteractionKind`].
+    /// - Nested interactions are the same [`InteractionKind`] as the last [`InteractionHierarchy::Begin`] interaction, except for [`InteractionKind::Protocol`] which can contain any [`InteractionKind`].
     fn validate(&self) -> Result<(), TranscriptError> {
         let mut stack = Vec::new();
         for (position, interaction) in self.interactions.iter().enumerate() {

--- a/spongefish/src/pattern/interaction_pattern.rs
+++ b/spongefish/src/pattern/interaction_pattern.rs
@@ -1,0 +1,190 @@
+use core::fmt::Display;
+
+use thiserror::Error;
+
+use super::{interaction::Hierarchy, Interaction, Kind};
+
+/// Abstract transcript containing prover-verifier interactions
+#[derive(Clone, PartialEq, Eq, Hash, PartialOrd, Ord, Debug, Default)]
+pub struct InteractionPattern {
+    interactions: Vec<Interaction>,
+}
+
+/// Errors when validating a transcript.
+#[derive(Clone, PartialEq, Eq, PartialOrd, Ord, Debug, Hash, Error)]
+pub enum TranscriptError {
+    #[error("Missing Begin for {end} at {position}")]
+    MissingBegin { position: usize, end: Interaction },
+    #[error(
+        "Invalid kind {interaction} at {interaction_position} for {begin} at {begin_position}"
+    )]
+    InvalidKind {
+        begin_position: usize,
+        begin: Interaction,
+        interaction_position: usize,
+        interaction: Interaction,
+    },
+    #[error("Mismatch {begin} at {begin_position} for {end} at {end_position}")]
+    MismatchedBeginEnd {
+        begin_position: usize,
+        begin: Interaction,
+        end_position: usize,
+        end: Interaction,
+    },
+    #[error("Missing End for {begin} at {position}")]
+    MissingEnd { position: usize, begin: Interaction },
+}
+
+impl InteractionPattern {
+    pub fn new(interactions: Vec<Interaction>) -> Result<Self, TranscriptError> {
+        let result = Self { interactions };
+        result.validate()?;
+        Ok(result)
+    }
+
+    #[must_use]
+    #[allow(clippy::missing_const_for_fn)] // False positive
+    pub fn interactions(&self) -> &[Interaction] {
+        &self.interactions
+    }
+
+    /// Generate a unique identifier for the protocol.
+    ///
+    /// It is created by taking the SHA3 hash of a stable unambiguous
+    /// string representation of the transcript interactions.
+    // TODO: A more neutral implementation would use ASN.1 DER.
+    #[must_use]
+    pub fn domain_separator(&self) -> [u8; 32] {
+        use sha3::{Digest, Sha3_256};
+        let mut hasher = Sha3_256::new();
+        // Use Display in `alternate` mode for stable unambiguous representation.
+        hasher.update(format!("{self:#}").as_bytes());
+        let result = hasher.finalize();
+        result.into()
+    }
+
+    /// Validate the transcript.
+    ///
+    /// A valid transcript has:
+    ///
+    /// - Matching [`InteractionHierachy::Begin`] and [`InteractionHierachy::End`] interactions
+    ///   creating a nested hierarchy.
+    /// - Nested interactions are the same [`InteractionKind`] as the last [`InteractionHierachy::Begin`] interaction, except for [`InteractionKind::Protocol`] which can contain any [`InteractionKind`].
+    fn validate(&self) -> Result<(), TranscriptError> {
+        let mut stack = Vec::new();
+        for (position, interaction) in self.interactions.iter().enumerate() {
+            match interaction.hierarchy() {
+                Hierarchy::Begin => stack.push((position, interaction)),
+                Hierarchy::End => {
+                    let Some((position, begin)) = stack.pop() else {
+                        dbg!();
+                        return Err(TranscriptError::MissingBegin {
+                            position,
+                            end: interaction.clone(),
+                        });
+                    };
+                    if !interaction.closes(begin) {
+                        return Err(TranscriptError::MismatchedBeginEnd {
+                            begin_position: position,
+                            begin: begin.clone(),
+                            end_position: self.interactions.len(),
+                            end: interaction.clone(),
+                        });
+                    }
+                }
+                Hierarchy::Atomic => {
+                    let Some((begin_position, begin)) = stack.last().copied() else {
+                        continue;
+                    };
+                    if begin.kind() != Kind::Protocol && begin.kind() != interaction.kind() {
+                        return Err(TranscriptError::InvalidKind {
+                            begin_position,
+                            begin: begin.clone(),
+                            interaction_position: position,
+                            interaction: interaction.clone(),
+                        });
+                    }
+                }
+            }
+        }
+        if let Some((position, begin)) = stack.pop() {
+            return Err(TranscriptError::MissingEnd {
+                position,
+                begin: begin.clone(),
+            });
+        }
+        Ok(())
+    }
+}
+
+/// Creates a human readable representation of the transcript.
+///
+/// When called in alternate mode `{:#}` it will be a stable format suitable as domain separator.
+impl Display for InteractionPattern {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        // Write the total interactions up front so no prefix string can be a valid domain separator.
+        let length = self.interactions.len();
+        let width = length.saturating_sub(1).to_string().len();
+        writeln!(f, "Spongefish Transcript ({length} interactions)")?;
+        let mut indentation = 0;
+        for (position, interaction) in self.interactions.iter().enumerate() {
+            write!(f, "{position:0>width$} ")?;
+            if interaction.hierarchy() == Hierarchy::End {
+                indentation -= 1;
+            }
+            for _ in 0..indentation {
+                write!(f, "  ")?;
+            }
+            if f.alternate() {
+                writeln!(f, "{interaction:#}")?;
+            } else {
+                writeln!(f, "{interaction}")?;
+            }
+            if interaction.hierarchy() == Hierarchy::Begin {
+                indentation += 1;
+            }
+        }
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::pattern::Length;
+
+    #[test]
+    fn test_size() {
+        dbg!(size_of::<TranscriptError>());
+        assert!(size_of::<TranscriptError>() < 170);
+    }
+
+    #[test]
+    fn test_domain_separator() {
+        let transcript = InteractionPattern::new(vec![
+            Interaction::new::<usize>(Hierarchy::Begin, Kind::Protocol, "test", Length::None),
+            Interaction::new::<Vec<f64>>(
+                Hierarchy::Atomic,
+                Kind::Message,
+                "test-message",
+                Length::Scalar,
+            ),
+            Interaction::new::<usize>(Hierarchy::End, Kind::Protocol, "test", Length::None),
+        ])
+        .unwrap();
+
+        let result = format!("{transcript:#}");
+        let expected = r"Spongefish Transcript (3 interactions)
+0 Begin Protocol 4 test None
+1   Atomic Message 12 test-message Scalar
+2 End Protocol 4 test None
+";
+        assert_eq!(result, expected);
+
+        let result = transcript.domain_separator();
+        assert_eq!(
+            hex::encode(result),
+            "33daf542c95b80a2b01be277d9d0f9b6d5bee823c5c3a0dcca71e614a5a783e3"
+        );
+    }
+}

--- a/spongefish/src/pattern/interaction_pattern.rs
+++ b/spongefish/src/pattern/interaction_pattern.rs
@@ -77,7 +77,6 @@ impl InteractionPattern {
                 Hierarchy::Begin => stack.push((position, interaction)),
                 Hierarchy::End => {
                     let Some((position, begin)) = stack.pop() else {
-                        dbg!();
                         return Err(TranscriptError::MissingBegin {
                             position,
                             end: interaction.clone(),

--- a/spongefish/src/pattern/interaction_pattern.rs
+++ b/spongefish/src/pattern/interaction_pattern.rs
@@ -54,7 +54,7 @@ impl InteractionPattern {
     /// string representation of the transcript interactions.
     // TODO: A more neutral implementation would use ASN.1 DER.
     #[must_use]
-    pub fn domain_separator(&self) -> [u8; 32] {
+    pub fn pattern_hash(&self) -> [u8; 32] {
         use sha3::{Digest, Sha3_256};
         let mut hasher = Sha3_256::new();
         // Use Display in `alternate` mode for stable unambiguous representation.
@@ -153,7 +153,7 @@ mod tests {
     use crate::pattern::Length;
 
     #[test]
-    fn test_domain_separator() {
+    fn test_pattern_hash() {
         let transcript = InteractionPattern::new(vec![
             Interaction::new::<usize>(Hierarchy::Begin, Kind::Protocol, "test", Length::None),
             Interaction::new::<Vec<f64>>(
@@ -174,7 +174,7 @@ mod tests {
 ";
         assert_eq!(result, expected);
 
-        let result = transcript.domain_separator();
+        let result = transcript.pattern_hash();
         assert_eq!(
             hex::encode(result),
             "33daf542c95b80a2b01be277d9d0f9b6d5bee823c5c3a0dcca71e614a5a783e3"

--- a/spongefish/src/pattern/interaction_pattern.rs
+++ b/spongefish/src/pattern/interaction_pattern.rs
@@ -154,12 +154,6 @@ mod tests {
     use crate::pattern::Length;
 
     #[test]
-    fn test_size() {
-        dbg!(size_of::<TranscriptError>());
-        assert!(size_of::<TranscriptError>() < 170);
-    }
-
-    #[test]
     fn test_domain_separator() {
         let transcript = InteractionPattern::new(vec![
             Interaction::new::<usize>(Hierarchy::Begin, Kind::Protocol, "test", Length::None),

--- a/spongefish/src/pattern/mod.rs
+++ b/spongefish/src/pattern/mod.rs
@@ -1,0 +1,136 @@
+//! Abstract interaction patterns for interactive protocols.
+
+mod interaction;
+mod interaction_pattern;
+mod pattern_player;
+mod pattern_state;
+
+pub use self::{
+    interaction::{Hierarchy, Interaction, Kind, Label, Length},
+    interaction_pattern::{InteractionPattern, TranscriptError},
+    pattern_player::PatternPlayer,
+    pattern_state::PatternState,
+};
+
+/// Trait for objects that implement hierarchy operations.
+///
+/// It does not offer any [`Kind::Atomic`] operations, these need to be implemented specifically.
+pub trait Pattern {
+    /// End a transcript without finalizing it.
+    ///
+    /// # Panics
+    ///
+    /// Panics only if the interaction is already finalized or aborted.
+    fn abort(&mut self);
+
+    /// Begin of a group of interactions.
+    ///
+    /// # Panics
+    ///
+    /// Panics if the interaction violates interaction pattern consistency rules.
+    fn begin<T: ?Sized>(&mut self, label: Label, kind: Kind, length: Length);
+
+    /// End of a group of interactions.
+    ///
+    /// # Panics
+    ///
+    /// Panics if the interaction violates interaction pattern consistency rules.
+    fn end<T: ?Sized>(&mut self, label: Label, kind: Kind, length: Length);
+
+    /// Begin of a subprotocol.
+    ///
+    /// # Panics
+    ///
+    /// Panics if the interaction violates interaction pattern consistency rules.
+    fn begin_protocol<T: ?Sized>(&mut self, label: Label) {
+        self.begin::<T>(label, Kind::Protocol, Length::None);
+    }
+
+    /// End of a subprotocol.
+    ///
+    /// # Panics
+    ///
+    /// Panics if the interaction violates interaction pattern consistency rules.
+    fn end_protocol<T: ?Sized>(&mut self, label: Label) {
+        self.end::<T>(label, Kind::Protocol, Length::None);
+    }
+
+    /// Begin of a public message interaction.
+    ///
+    /// # Panics
+    ///
+    /// Panics if the interaction violates interaction pattern consistency rules.
+    fn begin_public<T: ?Sized>(&mut self, label: Label, length: Length) {
+        self.begin::<T>(label, Kind::Public, length);
+    }
+
+    /// End of a public message interaction.
+    ///
+    /// # Panics
+    ///
+    /// Panics if the interaction violates interaction pattern consistency rules.
+    fn end_public<T: ?Sized>(&mut self, label: Label, length: Length) {
+        self.end::<T>(label, Kind::Public, length);
+    }
+
+    /// Begin of a message interaction.
+    ///
+    /// # Panics
+    ///
+    /// Panics if the interaction violates interaction pattern consistency rules.
+    fn begin_message<T: ?Sized>(&mut self, label: Label, length: Length) {
+        self.begin::<T>(label, Kind::Message, length);
+    }
+
+    /// End of a message interaction.
+    ///
+    /// # Panics
+    ///
+    /// Panics if the interaction violates interaction pattern consistency rules.
+    fn end_message<T: ?Sized>(&mut self, label: Label, length: Length) {
+        self.end::<T>(label, Kind::Message, length);
+    }
+
+    /// Begin of a hint interaction.
+    ///
+    /// # Panics
+    ///
+    /// Panics if the interaction violates interaction pattern consistency rules.
+    fn begin_hint<T: ?Sized>(&mut self, label: Label, length: Length) {
+        self.begin::<T>(label, Kind::Hint, length);
+    }
+
+    /// End of a hint interaction..
+    ///
+    /// # Panics
+    ///
+    /// Panics if the interaction violates interaction pattern consistency rules.
+    fn end_hint<T: ?Sized>(&mut self, label: Label, length: Length) {
+        self.end::<T>(label, Kind::Hint, length);
+    }
+
+    /// Begin of a challenge interaction..
+    ///
+    /// # Panics
+    ///
+    /// Panics if the interaction violates interaction pattern consistency rules.
+    fn begin_challenge<T: ?Sized>(&mut self, label: Label, length: Length) {
+        self.begin::<T>(label, Kind::Challenge, length);
+    }
+
+    /// End of a challenge interaction..
+    ///
+    /// # Panics
+    ///
+    /// Panics if the interaction violates interaction pattern consistency rules.
+    fn end_challenge<T: ?Sized>(&mut self, label: Label, length: Length) {
+        self.end::<T>(label, Kind::Challenge, length);
+    }
+}
+
+/// Aliases offered for convenience.
+pub use Pattern as Common;
+/// Aliases offered for convenience.
+pub use Pattern as Verifier;
+/// Aliases offered for convenience.
+pub use Pattern as Prover;

--- a/spongefish/src/pattern/mod.rs
+++ b/spongefish/src/pattern/mod.rs
@@ -134,3 +134,184 @@ pub use Pattern as Common;
 pub use Pattern as Verifier;
 /// Aliases offered for convenience.
 pub use Pattern as Prover;
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_record_playback() {
+        // Record a new pattern
+        let mut pattern = PatternState::<u8>::new();
+        pattern.begin_protocol::<()>("Example protocol");
+        pattern.interact(Interaction::new::<u64>(
+            Hierarchy::Atomic,
+            Kind::Challenge,
+            "nonce",
+            Length::Scalar,
+        ));
+        pattern.end_protocol::<()>("Example protocol");
+        let pattern = pattern.finalize();
+
+        // Play it back exactly
+        let mut playback = PatternPlayer::new(pattern.into());
+        playback.begin_protocol::<()>("Example protocol");
+        playback.interact(Interaction::new::<u64>(
+            Hierarchy::Atomic,
+            Kind::Challenge,
+            "nonce",
+            Length::Scalar,
+        ));
+        playback.end_protocol::<()>("Example protocol");
+        playback.finalize();
+    }
+
+    #[test]
+    #[should_panic(expected = "Dropped unfinalized transcript.")]
+    fn panics_if_playback_not_finalized() {
+        let mut pattern = PatternState::<u8>::new();
+        pattern.interact(Interaction::new::<u64>(
+            Hierarchy::Atomic,
+            Kind::Challenge,
+            "nonce",
+            Length::Scalar,
+        ));
+        let pattern = pattern.finalize();
+
+        let mut playback = PatternPlayer::new(pattern.into());
+        playback.interact(Interaction::new::<u64>(
+            Hierarchy::Atomic,
+            Kind::Challenge,
+            "nonce",
+            Length::Scalar,
+        ));
+    }
+
+    #[test]
+    #[should_panic(
+        expected = "Mismatched begin and end: Begin Protocol Example protocol None (), End Protocol Invalid example protocol None ()"
+    )]
+    fn panics_if_record_begin_end_mismatch() {
+        let mut pattern = PatternState::<u8>::new();
+        pattern.begin_protocol::<()>("Example protocol");
+        pattern.interact(Interaction::new::<u64>(
+            Hierarchy::Atomic,
+            Kind::Challenge,
+            "nonce",
+            Length::Scalar,
+        ));
+        pattern.end_protocol::<()>("Invalid example protocol");
+        let _pattern = pattern.finalize();
+    }
+    #[test]
+    #[should_panic(
+        expected = "Error validating interaction pattern: Missing End for Begin Protocol Example protocol None () at 0"
+    )]
+    fn panics_if_record_unmatched_begin() {
+        let mut pattern = PatternState::<u8>::new();
+        pattern.begin_protocol::<()>("Example protocol");
+        pattern.interact(Interaction::new::<u64>(
+            Hierarchy::Atomic,
+            Kind::Challenge,
+            "nonce",
+            Length::Scalar,
+        ));
+        let _pattern = pattern.finalize();
+    }
+
+    #[test]
+    #[should_panic(
+        expected = "Received interaction Atomic Challenge nonce Scalar f64, but expected Atomic Challenge nonce Scalar u64"
+    )]
+    fn panics_if_type_mismatch() {
+        let mut pattern = PatternState::<u8>::new();
+        pattern.interact(Interaction::new::<u64>(
+            Hierarchy::Atomic,
+            Kind::Challenge,
+            "nonce",
+            Length::Scalar,
+        ));
+        let pattern = pattern.finalize();
+
+        let mut playback = PatternPlayer::new(pattern.into());
+        playback.interact(Interaction::new::<f64>(
+            Hierarchy::Atomic,
+            Kind::Challenge,
+            "nonce",
+            Length::Scalar,
+        ));
+        playback.finalize();
+    }
+
+    #[test]
+    #[should_panic(
+        expected = "Received interaction Atomic Public nonce Scalar f64, but expected Atomic Message nonce Scalar u64"
+    )]
+    fn panics_if_kind_mismatch() {
+        let mut pattern = PatternState::<u8>::new();
+        pattern.interact(Interaction::new::<u64>(
+            Hierarchy::Atomic,
+            Kind::Message,
+            "nonce",
+            Length::Scalar,
+        ));
+        let pattern = pattern.finalize();
+
+        let mut playback = PatternPlayer::new(pattern.into());
+        playback.interact(Interaction::new::<f64>(
+            Hierarchy::Atomic,
+            Kind::Public,
+            "nonce",
+            Length::Scalar,
+        ));
+        playback.finalize();
+    }
+
+    #[test]
+    #[should_panic(
+        expected = "Received interaction Atomic Challenge invalid Scalar f64, but expected Atomic Challenge nonce Scalar u64"
+    )]
+    fn panics_if_label_mismatch() {
+        let mut pattern = PatternState::<u8>::new();
+        pattern.interact(Interaction::new::<u64>(
+            Hierarchy::Atomic,
+            Kind::Challenge,
+            "nonce",
+            Length::Scalar,
+        ));
+        let pattern = pattern.finalize();
+
+        let mut playback = PatternPlayer::new(pattern.into());
+        playback.interact(Interaction::new::<f64>(
+            Hierarchy::Atomic,
+            Kind::Challenge,
+            "invalid",
+            Length::Scalar,
+        ));
+        playback.finalize();
+    }
+
+    #[test]
+    #[should_panic(
+        expected = "Received interaction Atomic Challenge nonce Fixed(1) f64, but expected Atomic Challenge nonce Scalar u64"
+    )]
+    fn panics_if_length_mismatch() {
+        let mut pattern = PatternState::<u8>::new();
+        pattern.interact(Interaction::new::<u64>(
+            Hierarchy::Atomic,
+            Kind::Challenge,
+            "nonce",
+            Length::Scalar,
+        ));
+        let pattern = pattern.finalize();
+
+        let mut playback = PatternPlayer::new(pattern.into());
+        playback.interact(Interaction::new::<f64>(
+            Hierarchy::Atomic,
+            Kind::Challenge,
+            "nonce",
+            Length::Fixed(1),
+        ));
+        playback.finalize();
+    }
+}

--- a/spongefish/src/pattern/pattern_player.rs
+++ b/spongefish/src/pattern/pattern_player.rs
@@ -1,0 +1,86 @@
+use std::sync::Arc;
+
+use super::{Interaction, InteractionPattern, Kind, Label, Length};
+use crate::pattern::Hierarchy;
+
+/// Play back an interaction pattern and make sure all interactions match up.
+///
+/// # Panics
+///
+/// Panics on [`Drop`] if there are unfinished interactions.
+#[derive(Clone, PartialEq, Eq, PartialOrd, Ord, Hash, Debug)]
+pub struct PatternPlayer {
+    /// Shared reference to the transcript.
+    pattern: Arc<InteractionPattern>,
+    /// Current position in the interaction pattern.
+    position: usize,
+    /// Whether the transcript playback has been finalized.
+    finalized: bool,
+}
+
+impl PatternPlayer {
+    #[must_use]
+    pub const fn new(pattern: Arc<InteractionPattern>) -> Self {
+        Self {
+            pattern,
+            position: 0,
+            finalized: false,
+        }
+    }
+
+    /// Finalize the sequence of interactions. Returns an error if there
+    /// are unfinished interactions.
+    ///
+    /// # Panics
+    ///
+    /// Panics if the transcript is already finalized or if there are expected interactions left.
+    pub fn finalize(mut self) {
+        assert!(self.position <= self.pattern.interactions().len());
+        assert!(!self.finalized, "Transcript is already finalized.");
+        assert!(
+            self.position >= self.pattern.interactions().len(),
+            "Transcript not finished, expecting {}",
+            self.pattern.interactions()[self.position]
+        );
+        self.finalized = true;
+    }
+
+    /// Play the next interaction in the pattern.
+    ///
+    /// # Panics
+    ///
+    /// Panics if the transcript is already finalized or if the interaction does not match the expected one.
+    pub fn interact(&mut self, interaction: Interaction) {
+        assert!(!self.finalized, "Transcript is already finalized.");
+        let Some(expected) = self.pattern.interactions().get(self.position) else {
+            self.finalized = true;
+            panic!("Received interaction, but no more expected interactions: {interaction}");
+        };
+        if expected != &interaction {
+            self.finalized = true;
+            panic!("Received interaction {interaction}, but expected {expected}");
+        }
+        self.position += 1;
+    }
+}
+
+impl Drop for PatternPlayer {
+    fn drop(&mut self) {
+        assert!(self.finalized, "Dropped unfinalized transcript.");
+    }
+}
+
+impl super::Pattern for PatternPlayer {
+    fn abort(&mut self) {
+        assert!(!self.finalized, "Transcript is already finalized.");
+        self.finalized = true;
+    }
+
+    fn begin<T: ?Sized>(&mut self, label: Label, kind: Kind, length: Length) {
+        self.interact(Interaction::new::<T>(Hierarchy::Begin, kind, label, length));
+    }
+
+    fn end<T: ?Sized>(&mut self, label: Label, kind: Kind, length: Length) {
+        self.interact(Interaction::new::<T>(Hierarchy::End, kind, label, length));
+    }
+}

--- a/spongefish/src/pattern/pattern_state.rs
+++ b/spongefish/src/pattern/pattern_state.rs
@@ -1,0 +1,117 @@
+use std::marker::PhantomData;
+
+use super::{Hierarchy, Interaction, InteractionPattern, Kind, Label, Length};
+use crate::Unit;
+
+/// Records an interaction pattern.
+///
+/// # Panics
+///
+/// Panics on [`Drop`] if there are unfinished interactions.
+#[derive(Clone, PartialEq, Eq, PartialOrd, Ord, Hash, Debug, Default)]
+pub struct PatternState<U = u8>
+where
+    U: Unit,
+{
+    /// Recorded interactions.
+    interactions: Vec<Interaction>,
+    /// Whether the transcript playback has been finalized.
+    finalized: bool,
+    _unit: PhantomData<U>,
+}
+
+impl<U> PatternState<U>
+where
+    U: Unit,
+{
+    #[must_use]
+    pub const fn new() -> Self {
+        Self {
+            interactions: Vec::new(),
+            finalized: false,
+            _unit: PhantomData,
+        }
+    }
+
+    #[must_use]
+    pub fn finalize(self) -> InteractionPattern {
+        assert!(!self.finalized, "Transcript is already finalized.");
+        match InteractionPattern::new(self.interactions) {
+            Ok(transcript) => transcript,
+            Err(e) => panic!("Error validating interaction pattern: {e}"),
+        }
+    }
+
+    /// Add a new interaction to the pattern.
+    ///
+    /// # Panics
+    ///
+    /// Panics if
+    /// - the interaction does not match the parent kind and
+    ///   the parent kind is not [`Kind::Protocol`],
+    /// - the it is an [`Hierarchy::End`], but there is either no
+    ///   [`Hierarchy::Begin`] or it does not match the end.being
+    pub fn interact(&mut self, interaction: Interaction) {
+        assert!(!self.finalized, "Transcript is already finalized.");
+        if let Some(begin) = self.last_open_begin() {
+            // Check if the new interaction is of a permissible kind.
+            assert!(
+                begin.kind() == Kind::Protocol || begin.kind() == interaction.kind(),
+                "Invalid interaction kind: expected {}, got {}",
+                begin.kind(),
+                interaction.kind()
+            );
+            // Check if it is a matching End to the current Begin
+            assert!(
+                interaction.hierarchy() != Hierarchy::End || interaction.closes(begin),
+                "Mismatched begin and end: {begin}, {interaction}"
+            );
+        } else {
+            // No unclosed Begin interaction. Make sure this is not an end.
+            assert!(
+                interaction.hierarchy() != Hierarchy::End,
+                "Missing begin for {interaction}"
+            );
+        }
+
+        // All good, append
+        self.interactions.push(interaction);
+    }
+
+    /// Return the last unclosed [`Hierachy::Begin`] interaction.
+    fn last_open_begin(&self) -> Option<&Interaction> {
+        // Reverse search to find matching begin
+        let mut stack = 0;
+        for interaction in self.interactions.iter().rev() {
+            match interaction.hierarchy() {
+                Hierarchy::End => stack += 1,
+                Hierarchy::Begin => {
+                    if stack == 0 {
+                        return Some(interaction);
+                    }
+                    stack -= 1;
+                }
+                _ => {}
+            }
+        }
+        None
+    }
+}
+
+impl<U> super::Pattern for PatternState<U>
+where
+    U: Unit,
+{
+    fn abort(&mut self) {
+        assert!(!self.finalized, "Transcript is already finalized.");
+        self.finalized = true;
+    }
+
+    fn begin<T: ?Sized>(&mut self, label: Label, kind: Kind, length: Length) {
+        self.interact(Interaction::new::<T>(Hierarchy::Begin, kind, label, length));
+    }
+
+    fn end<T: ?Sized>(&mut self, label: Label, kind: Kind, length: Length) {
+        self.interact(Interaction::new::<T>(Hierarchy::End, kind, label, length));
+    }
+}

--- a/spongefish/src/pattern/pattern_state.rs
+++ b/spongefish/src/pattern/pattern_state.rs
@@ -78,7 +78,7 @@ where
         self.interactions.push(interaction);
     }
 
-    /// Return the last unclosed [`Hierachy::Begin`] interaction.
+    /// Return the last unclosed [`Hierarchy::Begin`] interaction.
     fn last_open_begin(&self) -> Option<&Interaction> {
         // Reverse search to find matching begin
         let mut stack = 0;


### PR DESCRIPTION
This adds a new `pattern` module that contains a representation of an interactive interaction pattern together with recording and playback states. The pattern contains types, labels and hierarchical grouping of (sub)protocols.

As discussed with @WizardOfMenlo, this only adds the pattern module for review and does not use it anywhere yet. The intention is for a follow up PR to use it as a substitute for `DomainSeparator`.