### PR TITLE
Fix Blake3 sequential solve test

### DIFF
--- a/pow/src/blake3.rs
+++ b/pow/src/blake3.rs
@@ -309,8 +309,11 @@ mod tests {
     fn test_solve_sequential() {
         let challenge = [2u8; 32];
         let mut pow = Blake3PoW::new(challenge, 10.0);
-        let nonce = pow.solve().expect("Should find a nonce");
-        assert!(pow.check(nonce), "Found nonce does not satisfy challenge");
+        let solution = pow.solve().expect("Should find a nonce");
+        assert!(
+            pow.check(solution.nonce),
+            "Found nonce does not satisfy challenge"
+        );
     }
 
     #[cfg(feature = "parallel")]

--- a/pow/src/blake3.rs
+++ b/pow/src/blake3.rs
@@ -176,12 +176,12 @@ impl Blake3PoW {
         // If the batch would overflow `u64`, stop at the last representable nonce
         // and zero the remaining lanes so they never get reported as valid.
         let mut valid_lanes = MAX_SIMD_DEGREE;
-        for i in 0..MAX_SIMD_DEGREE {
+        for (i, input) in self.inputs.iter_mut().enumerate() {
             let Some(batch_nonce) = nonce.checked_add(i as u64) else {
                 valid_lanes = i;
                 break;
             };
-            self.inputs[i][32..40].copy_from_slice(&batch_nonce.to_le_bytes());
+            input[32..40].copy_from_slice(&batch_nonce.to_le_bytes());
         }
         for input in &mut self.inputs[valid_lanes..] {
             input[32..40].fill(0);

--- a/spongefish/src/drivers/ark_ff_impl.rs
+++ b/spongefish/src/drivers/ark_ff_impl.rs
@@ -268,7 +268,7 @@ mod test_ark_ff {
         let ser = encode_to_vec(&p_minus_1);
         let mut sl: &[u8] = &ser;
         let de = F::deserialize_from_narg(&mut sl).expect("p-1 should deserialize");
-        assert!(sl.is_empty());
+        assert_eq!(sl, []);
         assert_eq!(de, p_minus_1);
     }
 

--- a/spongefish/tests/derive_generics.rs
+++ b/spongefish/tests/derive_generics.rs
@@ -37,7 +37,7 @@ fn codec_derive_handles_generic_types() {
     let mut buf: &[u8] = serialized.as_ref();
     let roundtrip = TaggedValue::<u8, 4>::deserialize_from_narg(&mut buf).expect("roundtrip");
     assert_eq!(roundtrip.value, tagged.value);
-    assert!(buf.is_empty());
+    assert_eq!(buf, []);
 
     #[allow(clippy::items_after_statements)]
     fn assert_codec<T: Codec>(_: &T) {}


### PR DESCRIPTION
## Summary

Fix the Blake3 sequential solver test to verify the nonce contained in the returned `PoWSolution`.

`PowStrategy::solve` returns a `PoWSolution`, while `PowStrategy::check` expects a `u64`. Passing the complete solution caused the Blake3-only, non-parallel test configuration to fail to compile.

## Testing

- `cargo test -p spongefish-pow --no-default-features --features blake3`
- `cargo test -p spongefish-pow`
- `cargo test -p spongefish-pow --all-features`
- `cargo clippy -p spongefish-pow --all-targets --no-default-features --features blake3 -- -D warnings`
- `cargo fmt --all -- --check`